### PR TITLE
libserial 1.0 compatibility

### DIFF
--- a/include/uDevice.h
+++ b/include/uDevice.h
@@ -48,7 +48,7 @@ struct uThingQueries_t {
 
 class Uthing {
 public:	
-	Uthing(const PortName& portName, PortObject portObj);
+	Uthing(const PortName& portName);
 
 	//getters:
 	std::string portName();

--- a/include/uDevice.h
+++ b/include/uDevice.h
@@ -49,6 +49,7 @@ struct uThingQueries_t {
 class Uthing {
 public:	
 	Uthing(const PortName& portName);
+	Uthing(Uthing&& other) noexcept;  // Move constructor
 
 	//getters:
 	std::string portName();

--- a/include/uSerial.h
+++ b/include/uSerial.h
@@ -38,7 +38,7 @@ class Bridge;
 // void monitorPortsThread(Devices& devices, std::mutex& mutex_devices, Config& config);
 void monitorPortsThread(Bridge* bridge);
 void findPorts(std::string devNameBase, PortList& portList);
-bool isUthing(const PortName& fileDescriptor, PortObject& port);
+bool isUthing(const PortName& fileDescriptor);
 	
 
 }//namespace ubridge

--- a/src/uSerial.cpp
+++ b/src/uSerial.cpp
@@ -158,7 +158,7 @@ void monitorPortsThread(Bridge* bridge) {
 				LOG_S(9) << "device at " << portName << " already created";
 			}
 		}
-		std::this_thread::sleep_for(std::chrono::milliseconds(500));
+		std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 	}//monitor loop
 }
 }//namespace ubridge

--- a/src/uSerial.cpp
+++ b/src/uSerial.cpp
@@ -54,7 +54,8 @@ void findPorts(std::string devNameBase, PortList& portList) {
 	}
 }
 
-bool isUthing(const PortName& fileDescriptor, PortObject& port) {
+bool isUthing(const PortName& fileDescriptor) {
+	PortObject port;
 	try {
 		port.Open(fileDescriptor);
 
@@ -132,14 +133,15 @@ void monitorPortsThread(Bridge* bridge) {
 
 			/* first check if a device is not already created on this port */
 			if (bridge->devices.find(portName) == bridge->devices.end()) {				
-				PortObject tempPort;
+				// PortObject tempPort;
 				json info;
 
 				LOG_S(5) << "Fetching info from device on " << portName;
-				if (isUthing(portName, tempPort)) {
+				if (isUthing(portName)) {
 					LOG_S(INFO) << "new uThing detected at " << portName;
-				
-					Uthing uThing(portName, std::move(tempPort));
+
+					// PortObject port;
+					Uthing uThing(portName);
 					uThing.assignChannelID();
 					
 					{


### PR DESCRIPTION
[workaround for the libserial serial port class lacking move constructor (it was added on a latter commit than the version available on debian) so we can use this older version without the need to compile the latest one, simplifying the installation process.